### PR TITLE
91 multiregion widget only recalc parameters for row being modified

### DIFF
--- a/cls/applications/pyStxm/widgets/scan_table_view/evScanTableModel.py
+++ b/cls/applications/pyStxm/widgets/scan_table_view/evScanTableModel.py
@@ -137,7 +137,7 @@ class EnergyScanTableModel(BaseScanTableModel):
                         on_step_size_changed(scan)
 
                     # finally make sure all scans obey ascending eV rule
-                    self.recalc_params(row + 1)
+                    # self.recalc_params(row + 1)
 
         if (role == QtCore.Qt.EditRole) or (role == QtCore.Qt.DisplayRole):
             # must emit this as part of the framework support for an editable AbstractTableModel

--- a/cls/applications/pyStxm/widgets/scan_table_view/multiRegionWidget.py
+++ b/cls/applications/pyStxm/widgets/scan_table_view/multiRegionWidget.py
@@ -314,7 +314,8 @@ class MultiRegionWidget(BaseSelectionWidget):
             self.ev_widg.set_table_to_editable(False)
             self.pol_widg.set_table_to_editable(False)
             self.ev_widg.setEnabled(False)
-            self.pol_widg.setEnabled(False)
+            # allow polarization to be enabled
+            # self.pol_widg.setEnabled(False)
         else:
             self.ev_widg.emit_new_total()
             self.singleEvFld.setEnabled(False)


### PR DESCRIPTION
 - Prevent all subsequent rows from recalculating, this now allows users to configure overlapping energy regions either on purpose or by accident
 - allow polarization to be enabled if set to single energy
closes #91 